### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
+[![Latest Stable Version](https://poser.pugx.org/sudhaus7/sudhaus7-gpgadmin/v/stable.svg)](https://extensions.typo3.org/extension/sudhaus7_gpgadmin/)
 [![TYPO3 11](https://img.shields.io/badge/TYPO3-11-orange.svg)](https://get.typo3.org/version/11)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg)](https://get.typo3.org/version/10)
+[![Total Downloads](https://poser.pugx.org/sudhaus7/sudhaus7-gpgadmin/d/total.svg)](https://packagist.org/packages/sudhaus7/sudhaus7-gpgadmin)
+[![Monthly Downloads](https://poser.pugx.org/sudhaus7/sudhaus7-gpgadmin/d/monthly)](https://packagist.org/packages/sudhaus7/sudhaus7-gpgadmin)
 ![PHPSTAN:Level 9](https://img.shields.io/badge/PHPStan-level%209-brightgreen.svg?style=flat])
 ![build:passing](https://img.shields.io/badge/build-passing-brightgreen.svg?style=flat])
-![build:passing](https://img.shields.io/badge/Version-3.0.0-blue.svg?style=flat])
 
 # TYPO3 extension `sudhaus7_gpgadmin`
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,12 @@
 {
   "name": "sudhaus7/sudhaus7-gpgadmin",
   "description": "(Sudhaus7) This TYPO3 extension adds an EXT:form finisher and a record type for managing GPG/PGP/OpenPGP keys and sending GPG/PGP encrypted (and signed) emails from your forms.",
+  "homepage": "https://extensions.typo3.org/extension/sudhaus7_gpgadmin",
+  "support": {
+    "docs": "https://docs.typo3.org/p/sudhaus7/sudhaus7-gpgadmin/main/en-us/",
+    "issues": "https://github.com/sudhaus7/typo3-gpgadmin/issues",
+    "source": "https://github.com/sudhaus7/typo3-gpgadmin"
+  },
   "version": "3.0.2",
   "type": "typo3-cms-extension",
   "license": "MIT",


### PR DESCRIPTION
Added two new commits regarding badges in README and additional sources (TER, repository and docs.typo3.org) in composer.json.

What is missing:
Remove any documentation URL from the "External manual" field of the TER extension page configuration at https://extensions.typo3.org/ as the documentation at docs.typo3.org is detected automatically and a specific URL is error-prone.

Relates: TYPO3-Documentation/T3DocTeam#185